### PR TITLE
FIXED: Summary Texts Overflow

### DIFF
--- a/lib/widgets/summary_widget/main/main_text/main_text_count.dart
+++ b/lib/widgets/summary_widget/main/main_text/main_text_count.dart
@@ -7,7 +7,9 @@ class TextCountWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Text((count != null ? count.toString() : "..."),
-              style: TextStyle(fontSize: fontSize, fontWeight: FontWeight.bold));
+    return  Expanded(
+      child: Text((count != null ? count.toString() : "..."),
+            style: TextStyle(fontSize: fontSize, fontWeight: FontWeight.bold)),
+    );
   }
 }

--- a/lib/widgets/summary_widget/main/main_total_cases.dart
+++ b/lib/widgets/summary_widget/main/main_total_cases.dart
@@ -11,16 +11,19 @@ class TotalCases extends SummaryBase {
     return Container(
       width: MediaQuery.of(context).size.width,
       height: mainHeight * 2,
-      padding: EdgeInsets.symmetric(horizontal: 30.0, vertical: 20.0),
       decoration: BoxDecoration(color: totalCasesBgColor),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        mainAxisAlignment: MainAxisAlignment.spaceBetween,
-        children: [
-          MainTextLabel(label: 'Total Cases', fontSize: 16),
-          TextCountWidget(count: count, fontSize: summaryMainFontSize)
-        ],
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 30.0, vertical: 20.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            MainTextLabel(label: 'Total Cases', fontSize: 16),
+            TextCountWidget(count: count, fontSize: summaryMainFontSize)
+          ],
+        ),
       ),
+      // padding: EdgeInsets.symmetric(horizontal: 30.0, vertical: 20.0),
     );
   }
 }

--- a/lib/widgets/summary_widget/sub/sub_text/sub_text_label.dart
+++ b/lib/widgets/summary_widget/sub/sub_text/sub_text_label.dart
@@ -7,7 +7,9 @@ class TextLabelWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Text(label,
-              style: TextStyle(fontSize: fontSize, fontWeight: FontWeight.w300));
+    return Expanded(
+      child: Text(label,
+                style: TextStyle(fontSize: fontSize, fontWeight: FontWeight.w300)),
+    );
   }
 }


### PR DESCRIPTION
Wrapped summary texts inside Expanded class to avoid overflow. 🩹 